### PR TITLE
simplifies build.jl script

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,14 +1,11 @@
 using BinaryProvider
 using Compat
 
-const verbose = "--verbose" in ARGS
-const prefix = Prefix(joinpath(@__DIR__, "usr"))
+depsdir(args...) = joinpath(@__DIR__, args...)
 
-# BinaryProvider v0.3.2 has libdir(prefix) bug on windows
-@static if Compat.Sys.iswindows()
-    file_path = joinpath(prefix.path, "lib", string("pa_ringbuffer_", Sys.ARCH, "-w64-mingw32.dll"))
-    product = FileProduct(file_path, :libpa_ringbuffer)
+product = LibraryProduct(depsdir("usr", "lib"), "pa_ringbuffer", :libpa_ringbuffer)
+if satisfied(product; verbose=true)
+    write_deps_file(depsdir("deps.jl"), [product])
 else
-    product = LibraryProduct(prefix, "pa_ringbuffer", :libpa_ringbuffer)
+    throw(ErrorException("Failed to satisfy pa_ringbuffer library dependency"))
 end
-satisfied(product; verbose=verbose) && write_deps_file(joinpath(@__DIR__, "deps.jl"), [product])


### PR DESCRIPTION
also now will load locally-built pa_ringbuffer library